### PR TITLE
delete /tasks/:id においてCORSの対応を入れる

### DIFF
--- a/controller/task.go
+++ b/controller/task.go
@@ -110,6 +110,12 @@ func PutTask(w http.ResponseWriter, r *http.Request) {
 }
 
 func DeleteTask(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	if r.Method == http.MethodOptions {
+		return
+	}
 	params := mux.Vars(r)
 	taskUUID := params["uuid"]
 	exist, err := model.CheckTaskExist(taskUUID)

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	router.HandleFunc("/tasks", controller.GetTasks).Methods(http.MethodGet)
 	router.HandleFunc("/tasks/{uuid}", controller.GetTask).Methods(http.MethodGet)
 	router.HandleFunc("/tasks/{uuid}", controller.PutTask).Methods(http.MethodPut)
-	router.HandleFunc("/tasks/{uuid}", controller.DeleteTask).Methods(http.MethodDelete)
+	router.HandleFunc("/tasks/{uuid}", controller.DeleteTask).Methods(http.MethodDelete, http.MethodOptions)
 	log.Print(http.ListenAndServe("0.0.0.0:8080", router))
 	os.Exit(1)
 }

--- a/view/error.go
+++ b/view/error.go
@@ -26,6 +26,7 @@ func RenderInternalServerError(w http.ResponseWriter, statusCode int, messages [
 
 func RenderBadRequest(w http.ResponseWriter, messages []string) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.WriteHeader(http.StatusBadRequest)
 	enc := json.NewEncoder(w)
 	enc.Encode(&errorsResponse{Status: "bad request", ErrorMessages: messages})
@@ -33,6 +34,7 @@ func RenderBadRequest(w http.ResponseWriter, messages []string) {
 
 func RenderNotFound(w http.ResponseWriter, tableName string, uuid string) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.WriteHeader(http.StatusNotFound)
 	enc := json.NewEncoder(w)
 	enc.Encode(&errorResponse{


### PR DESCRIPTION
optionメソッドの時は下のヘッダを付いた状態で返す。(deleteでもつく)
```go
w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
w.Header().Set("Access-Control-Allow-Origin", "*")
w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
```
close #1 